### PR TITLE
Post title [fix #18]

### DIFF
--- a/src/templates/Post.vue
+++ b/src/templates/Post.vue
@@ -25,7 +25,12 @@ Layout
 
 <script lang="ts">
 export default {
-    name: "Post"
+  name: "Post",
+  metaInfo() {
+    return {
+      title: this.$page.post.title
+    }
+  }
 }
 </script>
 


### PR DESCRIPTION
Fixes error referenced in issue #18 

`Johnathan Irvin - Johnathan Irvin` in the title of the webpage on posts becomes `Name of Article - Johnathan Irvin`.